### PR TITLE
Preview design updates in download modal

### DIFF
--- a/web-app/PDF/DownloadModal.tsx
+++ b/web-app/PDF/DownloadModal.tsx
@@ -210,10 +210,12 @@ export default function DownloadModal(props: DownloadModalProps) {
                                 {selectableDesigns.map(design => (
                                     <SelectItem key={design.id}>
                                         <div className="flex items-start gap-3 py-1">
-                                            <DesignPreview design={design} allDesigns={DESIGNS} />
-                                            <div>
+                                            <div className="shrink-0">
+                                                <DesignPreview design={design} allDesigns={DESIGNS} />
+                                            </div>
+                                            <div className="min-w-0">
                                                 <Text fw={"600"}>{design.name}</Text>
-                                                <div className="text-sm text-gray-500">
+                                                <div className="text-sm text-gray-500 break-words">
                                                     {design.description}
                                                 </div>
                                             </div>

--- a/web-app/PDF/HardDesigns.tsx
+++ b/web-app/PDF/HardDesigns.tsx
@@ -4,7 +4,7 @@ export const DESIGNS: HardDesignPreset[] = [
     {
         id: "like-hitster",
         name: "Like-Hitster",
-        description: "Enthält alle Like-Hitster-Designs und wechselt diese pro Karte ab.",
+        description: "Ein Design sehr nah an dem Original-Design von Hitster, mit einem Rückseitendesign, das an die Rückseite der Original-Hitster-Karten erinnert.",
         includes: ["like-hitster-blue", "like-hitster-green", "like-hitster-yellow", "like-hitster-purple", "like-hitster-red", "like-hitster-teal"],
     },
     {


### PR DESCRIPTION
This pull request enhances the design selection experience in the `DownloadModal` by introducing a visual preview of each design, improving the UI layout, and clarifying design descriptions. The most important changes are grouped below:

**UI/UX Improvements:**

* Added a new `DesignPreview` component to visually display the front and back backgrounds of each design option in the selection dropdown, making it easier for users to distinguish between designs. (`web-app/PDF/DownloadModal.tsx`, [web-app/PDF/DownloadModal.tsxR23-R72](diffhunk://#diff-4a4b7c59252c255269a076e69b37d3b1d899f04843cefb766ba73acc95b0e1edR23-R72))
* Updated the layout of the design selection dropdown to use the new `DesignPreview` and improved spacing and text wrapping for better readability. (`web-app/PDF/DownloadModal.tsx`, [web-app/PDF/DownloadModal.tsxL167-R218](diffhunk://#diff-4a4b7c59252c255269a076e69b37d3b1d899f04843cefb766ba73acc95b0e1edL167-R218))

**Content and Description Updates:**

* Clarified and expanded the description for the "Like-Hitster" design to better reflect its resemblance to the original Hitster cards. (`web-app/PDF/HardDesigns.tsx`, [web-app/PDF/HardDesigns.tsxL7-R7](diffhunk://#diff-7c865f581fec2e768096ab3d843cf053af862bb79d32ac77e4e38183348c0783L7-R7))
* Fixed a minor typo in the design selection dropdown description ("designs" → "Designs"). (`web-app/PDF/DownloadModal.tsx`, [web-app/PDF/DownloadModal.tsxL139-R184](diffhunk://#diff-4a4b7c59252c255269a076e69b37d3b1d899f04843cefb766ba73acc95b0e1edL139-R184))