### PR TITLE
fix: resolve #100 — [Task]: Beim Spielen das Handydisplay eingeschaltet lassen

### DIFF
--- a/web-app/src/hooks/useWakeLock.ts
+++ b/web-app/src/hooks/useWakeLock.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react';
+
+export function useWakeLock(active: boolean) {
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+
+  const releaseLock = async () => {
+    if (wakeLockRef.current) {
+      try {
+        await wakeLockRef.current.release();
+        wakeLockRef.current = null;
+      } catch (error) {
+        console.error('Failed to release wake lock:', error);
+      }
+    }
+  };
+
+  const requestLock = async () => {
+    if (!('wakeLock' in navigator)) {
+      return;
+    }
+    if (!active || document.visibilityState !== 'visible') {
+      return;
+    }
+    try {
+      const lock = await navigator.wakeLock.request('screen');
+      wakeLockRef.current = lock;
+      lock.addEventListener('release', () => {
+        wakeLockRef.current = null;
+      });
+    } catch (error) {
+      console.error('Failed to request wake lock:', error);
+    }
+  };
+
+  useEffect(() => {
+    if (active && document.visibilityState === 'visible') {
+      requestLock();
+    } else {
+      releaseLock();
+    }
+
+    const handleVisibilityChange = () => {
+      if (active && document.visibilityState === 'visible') {
+        requestLock();
+      } else if (document.visibilityState === 'hidden') {
+        releaseLock();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      releaseLock();
+    };
+  }, [active]);
+}


### PR DESCRIPTION
## Summary

fix: resolve #100 — [Task]: Beim Spielen das Handydisplay eingeschaltet lassen

## Problem

**Severity**: `Medium` | **File**: `web-app/src/hooks/useWakeLock.ts`

This hook provides a way to request and release the screen wake lock based on an active flag. It handles browser compatibility, visibility change events (reacquire lock when page becomes visible again), and cleanup on unmount. The lock is only requested when `active` is true and the document is visible. It also logs errors gracefully.

## Solution

Create a new file `useWakeLock.ts` inside `web-app/src/hooks/`. Implement using the WakeLock API. The hook should accept a boolean `active` flag. Use `useRef` to store the current wake lock object. Use `useEffect` to watch `active` and visibility state. If `active` and document visible, request lock. On visibility change, release if inactive or hidden, re-request if active and visible. Clean up by releasing lock on unmount. Return nothing.

## Changes

- `web-app/src/hooks/useWakeLock.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"