### PR TITLE
fix: resolve #99 — [US]: Jahresverteilung eines Decks

### DIFF
--- a/src/components/pages/LabsPage/ViewDeckModal.tsx
+++ b/src/components/pages/LabsPage/ViewDeckModal.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../ui/Dialog';
+import { YearDistribution } from '../../ui/YearDistribution/YearDistribution';
+import { Deck } from '../../../types/deck';
+
+interface ViewDeckModalProps {
+  deck: Deck;
+  onClose: () => void;
+}
+
+export const ViewDeckModal: React.FC<ViewDeckModalProps> = ({ deck, onClose }) => {
+  const songs = deck.songs || [];
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{deck.name}</DialogTitle>
+        </DialogHeader>
+        <div className="mt-4">
+          <h3 className="font-semibold">Songs</h3>
+          <ul className="list-disc pl-5">
+            {songs.map(song => (
+              <li key={song.id}>{song.title} ({song.year})</li>
+            ))}
+          </ul>
+          <div className="mt-4">
+            <YearDistribution songs={songs} />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/hooks/useDeckSongs.ts
+++ b/src/hooks/useDeckSongs.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+
+interface Song {
+  id: string;
+  title: string;
+  artist: string;
+  year?: number;
+  [key: string]: any;
+}
+
+export function useDeckSongs(deckId: string) {
+  const [songs, setSongs] = useState<Song[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!deckId) return;
+    setLoading(true);
+    fetch(`/api/decks/${deckId}/songs`)
+      .then(res => res.json())
+      .then(data => {
+        const songsWithYear = data.map((song: any) => {
+          if (song.year !== undefined) return song;
+          let year: number | undefined;
+          if (song.release_year) year = song.release_year;
+          else if (song.release_date) year = new Date(song.release_date).getFullYear();
+          return { ...song, year };
+        });
+        setSongs(songsWithYear);
+        setLoading(false);
+      })
+      .catch(err => {
+        setError(err.message);
+        setLoading(false);
+      });
+  }, [deckId]);
+
+  return { songs, loading, error };
+}


### PR DESCRIPTION
## Summary

fix: resolve #99 — [US]: Jahresverteilung eines Decks

## Problem

**Severity**: `Medium` | **File**: `src/components/pages/LabsPage/ViewDeckModal.tsx`

Extend the ViewDeckModal component to show the year distribution of the deck's songs, using the newly created YearDistribution component.

## Solution

Import `YearDistribution` from `../../ui/YearDistribution/YearDistribution`. Obtain the list of songs belonging to the deck. If the modal currently receives a `deck` object with songs, pass `deck.songs` to the component. If songs are fetched asynchronously (e.g., using `useDeckSongs`), call that hook inside the modal. Add the `<YearDistribution songs={songs} />` inside the modal body, typically after the song list or before. Example placement:

## Changes

- `src/components/pages/LabsPage/ViewDeckModal.tsx` (new)
- `src/hooks/useDeckSongs.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"