### PR TITLE
fix: resolve #98 — [Bug]: Error flasche spotify scopes um öffentliche playlists auszulesen

### DIFF
--- a/web-app/src/components/pages/LoginPage.tsx
+++ b/web-app/src/components/pages/LoginPage.tsx
@@ -54,7 +54,7 @@ export default function LoginPage() {
             provider: "spotify",
             options: {
                 redirectTo: `${window.location.origin}/login`,
-                scopes: SPOTIFY_SCOPES,
+                scopes: SPOTIFY_SCOPES + ' playlist-read-public',
             },
         });
     };


### PR DESCRIPTION
## Summary

fix: resolve #98 — [Bug]: Error flasche spotify scopes um öffentliche playlists auszulesen

## Problem

**Severity**: `High` | **File**: `web-app/src/components/pages/LoginPage.tsx`

The Spotify OAuth flow currently requests insufficient scopes, leading to 403 errors when the app tries to fetch public playlists. This change adds the required scope to the authentication request, ensuring the access token grants permission to read public playlists.

## Solution

Locate the function that initiates Spotify OAuth (likely using Supabase Auth or direct Spotify SDK). Modify the `scopes` parameter to include `'playlist-read-public'`. If using Supabase, update the `signInWithOAuth` call:

## Changes

- `web-app/src/components/pages/LoginPage.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"