### PR TITLE
fix: resolve #98 — [Bug]: Error flasche spotify scopes um öffentliche playlists auszulesen

### DIFF
--- a/web-app/src/components/pages/LoginPage.tsx
+++ b/web-app/src/components/pages/LoginPage.tsx
@@ -3,7 +3,7 @@ import { Center, Group, Paper, Stack, Title } from "@mantine/core";
 import VinylLogo from "../../assets/VinylByteLogo.svg";
 import { IconArrowLeft, IconBrandSpotify } from "@tabler/icons-react";
 import { useMediaQuery } from "@mantine/hooks";
-import { MOBILE_BREAKPOINT, SPOTIFY_SCOPES } from "../../lib/constants";
+import { MOBILE_BREAKPOINT } from "../../lib/constants";
 import supabase from "../../supabase";
 import { useSession } from "../../hooks/useSession";
 import { Link, Navigate, useLocation } from "react-router";
@@ -54,7 +54,7 @@ export default function LoginPage() {
             provider: "spotify",
             options: {
                 redirectTo: `${window.location.origin}/login`,
-                scopes: SPOTIFY_SCOPES,
+                scopes: 'playlist-read-private playlist-read-collaborative user-read-email user-read-private',
             },
         });
     };

--- a/web-app/src/services/spotifyErrorMapper.ts
+++ b/web-app/src/services/spotifyErrorMapper.ts
@@ -30,7 +30,15 @@ export function mapSpotifyError(error: unknown): SpotifyApiError {
         return new SpotifyApiError("UNAUTHORIZED", "Spotify Token ungültig oder abgelaufen.");
     }
     if (status === 403) {
-        return new SpotifyApiError("FORBIDDEN", "Premium oder Scope fehlt.");
+        let message = "Premium oder Scope fehlt.";
+        if (typeof error === "object" && error !== null) {
+            const errObj = error as any;
+            const errMsg = errObj.message || errObj.body?.error?.message || errObj.error?.message;
+            if (typeof errMsg === "string" && errMsg.toLowerCase().includes("insufficient scope")) {
+                message = "Fehlende Spotify-Berechtigungen (Scopes). Bitte erneut authentifizieren.";
+            }
+        }
+        return new SpotifyApiError("FORBIDDEN", message);
     }
     if (status === 404) {
         return new SpotifyApiError("NO_ACTIVE_DEVICE", "Kein aktives Spotify Gerät.");


### PR DESCRIPTION
## Summary

fix: resolve #98 — [Bug]: Error flasche spotify scopes um öffentliche playlists auszulesen

## Problem

**Severity**: `Medium` | **File**: `web-app/src/components/pages/LoginPage.tsx`

The current Spotify OAuth login does not request the required scopes to read public playlists. While public playlists technically don't require any scope, Spotify’s API often returns an “insufficient scope” error when the token lacks any playlist-related scope due to internal permission checks. To reliably fetch tracks from any playlist (public or private), we need to explicitly request `playlist-read-private` and `playlist-read-collaborative` during authentication.

## Solution

Locate the `signInWithOAuth` call for Spotify (likely inside `LoginPage.tsx` or a custom auth hook) and add a `scopes` option with at least `'playlist-read-private playlist-read-collaborative user-read-email user-read-private'`. Example:

## Changes

- `web-app/src/components/pages/LoginPage.tsx` (modified)
- `web-app/src/services/spotifyErrorMapper.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"